### PR TITLE
Two step sandbox overlay

### DIFF
--- a/wasm-demo/src/components/app/setup-step.js
+++ b/wasm-demo/src/components/app/setup-step.js
@@ -20,8 +20,6 @@ export default ( { onSubmit } ) => {
 	const { themes, activeTheme, setActiveTheme } = useThemes();
 	const { plugins, activePlugins, toggleActivePlugin } = usePlugins();
 
-	const mShotsUrl = 'https://wordpress.com/mshots/v1/';
-
 	return (
 		<Modal
 			isFullScreen={ true }
@@ -62,11 +60,7 @@ export default ( { onSubmit } ) => {
 										gap={ 0 }
 									>
 										<FlexItem>
-											<img
-												src={ `${ mShotsUrl }${ encodeURIComponent(
-													theme.url + '?v=20221125'
-												) }` }
-											/>
+											<img src={ theme.thumbnail } />
 										</FlexItem>
 										<FlexBlock
 											as="h3"

--- a/wasm-demo/src/components/app/setup-step.js
+++ b/wasm-demo/src/components/app/setup-step.js
@@ -86,8 +86,9 @@ export default ( { onSubmit } ) => {
 					</h4>
 					<Flex
 						className="wporg-tab-item-list is-plugin"
+						justify="flex-start"
 						wrap={ true }
-						gap="16px"
+						gap="8px"
 					>
 						{ plugins.map( ( plugin ) => (
 							<FlexItem
@@ -102,7 +103,7 @@ export default ( { onSubmit } ) => {
 							>
 								<a href="#">
 									<Flex
-										align="flex-start"
+										align="center"
 										direction="row"
 										gap={ 2 }
 									>

--- a/wasm-demo/src/components/app/setup-step.js
+++ b/wasm-demo/src/components/app/setup-step.js
@@ -82,7 +82,7 @@ export default ( { onSubmit } ) => {
 					</Flex>
 
 					<h4 className="wporg-section-title">
-						2. Choose a few plugins
+						2. Add a few plugins
 					</h4>
 					<Flex
 						className="wporg-tab-item-list is-plugin"

--- a/wasm-demo/src/hooks/plugins.js
+++ b/wasm-demo/src/hooks/plugins.js
@@ -13,6 +13,31 @@ const plugins = [
 		icon: 'https://ps.w.org/coblocks/assets/icon-256x256.jpg'
 	},
 	{
+		name: 'bbPress',
+		zip: 'bbpress.latest-stable.zip',
+		icon: 'https://ps.w.org/bbpress/assets/icon-256x256.png?rev=1331499'
+	},
+	{
+		name: 'BuddyPress',
+		zip: 'buddypress.latest-stable.zip',
+		icon: 'https://ps.w.org/buddypress/assets/icon-256x256.png?rev=1331499'
+	},
+	{
+		name: 'Gutenberg',
+		zip: 'gutenberg.latest-stable.zip',
+		icon: 'https://ps.w.org/gutenberg/assets/icon-256x256.jpg'
+	},
+	{
+		name: 'Classic Editor',
+		zip: 'classic-editor.latest-stable.zip',
+		icon: 'https://ps.w.org/classic-editor/assets/icon-256x256.png'
+	},
+	{
+		name: 'Yoast SEO',
+		zip: 'wordpress-seo.latest-stable.zip',
+		icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.png'
+	},
+	{
 		name: 'Duplicate Page',
 		zip: 'duplicate-page.latest-stable.zip',
 		icon: 'https://ps.w.org/duplicate-page/assets/icon-128x128.jpg'
@@ -26,31 +51,6 @@ const plugins = [
 		name: 'Advanced Custom Fields',
 		zip: 'advanced-custom-fields.latest-stable.zip',
 		icon: 'https://ps.w.org/advanced-custom-fields/assets/icon-256x256.png'
-	},
-	{
-		name: 'Polylang',
-		zip: 'polylang.latest-stable.zip',
-		icon: 'https://ps.w.org/polylang/assets/icon-256x256.png?rev=1331499'
-	},
-	{
-		name: 'Gutenberg',
-		zip: 'gutenberg.latest-stable.zip',
-		icon: 'https://ps.w.org/gutenberg/assets/icon-256x256.jpg'
-	},
-	{
-		name: 'Classic Editor',
-		zip: 'classic-editor.latest-stable.zip',
-		icon: 'https://ps.w.org/classic-editor/assets/icon-256x256.png'
-	},
-	{
-		name: 'Hello Dolly',
-		zip: 'hello-dolly.latest-stable.zip',
-		icon: 'https://ps.w.org/hello-dolly/assets/icon-256x256.jpg'
-	},
-	{
-		name: 'Yoast SEO',
-		zip: 'wordpress-seo.latest-stable.zip',
-		icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.png'
 	},
 ];
 

--- a/wasm-demo/src/hooks/plugins.js
+++ b/wasm-demo/src/hooks/plugins.js
@@ -8,11 +8,6 @@ const StateContext = createContext();
 
 const plugins = [
 	{
-		name: 'WooCommerce',
-		zip: 'woocommerce.latest-stable.zip',
-		icon: 'https://ps.w.org/woocommerce/assets/icon-256x256.png'
-	},
-	{
 		name: 'Coblocks',
 		zip: 'coblocks.latest-stable.zip',
 		icon: 'https://ps.w.org/coblocks/assets/icon-256x256.jpg'
@@ -51,6 +46,11 @@ const plugins = [
 		name: 'Hello Dolly',
 		zip: 'hello-dolly.latest-stable.zip',
 		icon: 'https://ps.w.org/hello-dolly/assets/icon-256x256.jpg'
+	},
+	{
+		name: 'Yoast SEO',
+		zip: 'wordpress-seo.latest-stable.zip',
+		icon: 'https://ps.w.org/wordpress-seo/assets/icon-256x256.png'
 	},
 ];
 

--- a/wasm-demo/src/hooks/themes.js
+++ b/wasm-demo/src/hooks/themes.js
@@ -25,6 +25,36 @@ const themes = [
 		name: 'Twenty Twenty-One',
 		zip: 'twentytwentyone.latest-stable.zip',
 	},
+	{
+		url: 'https://wp-themes.com/astra',
+		thumbnail: 'https://i0.wp.com/themes.svn.wordpress.org/astra/3.9.4/screenshot.jpg?w=572&strip=all',
+		name: 'Astra',
+		zip: 'astra.latest-stable.zip',
+	},
+	{
+		url: 'https://wp-themes.com/twentytwenty',
+		thumbnail: 'https://i0.wp.com/themes.svn.wordpress.org/twentytwenty/2.1/screenshot.png?w=572&strip=all',
+		name: 'Twenty Twenty',
+		zip: 'twentytwenty.latest-stable.zip',
+	},
+	{
+		url: 'https://wp-themes.com/oceanwp',
+		thumbnail: 'https://i0.wp.com/themes.svn.wordpress.org/oceanwp/3.3.6/screenshot.png?w=572&strip=all',
+		name: 'OceanWP',
+		zip: 'oceanwp.latest-stable.zip',
+	},
+	{
+		url: 'https://wp-themes.com/twentyseventeen',
+		thumbnail: 'https://i0.wp.com/themes.svn.wordpress.org/twentyseventeen/3.1/screenshot.png?w=572&strip=all',
+		name: 'Twenty Seventeen',
+		zip: 'twentyseventeen.latest-stable.zip',
+	},
+	{
+		url: 'https://wp-themes.com/neve',
+		thumbnail: 'https://i0.wp.com/themes.svn.wordpress.org/neve/3.4.5/screenshot.png?w=572&strip=all',
+		name: 'Neve',
+		zip: 'neve.latest-stable.zip',
+	},
 ];
 export const ThemesProvider = ( { children } ) => {
 	const [activeTheme, _setActiveTheme] = useState(() => {

--- a/wasm-demo/src/hooks/themes.js
+++ b/wasm-demo/src/hooks/themes.js
@@ -9,16 +9,19 @@ const StateContext = createContext();
 const themes = [
 	{
 		url: 'https://wp-themes.com/twentytwentythree',
+		thumbnail: 'https://i0.wp.com/themes.svn.wordpress.org/twentytwentythree/1.0/screenshot.png?w=572&strip=all',
 		name: 'Twenty Twenty-Three',
 		zip: 'twentytwentythree.latest-stable.zip',
 	},
 	{
 		url: 'https://wp-themes.com/twentytwentytwo',
+		thumbnail: 'https://i0.wp.com/themes.svn.wordpress.org/twentytwentytwo/1.3/screenshot.png?w=572&strip=all',
 		name: 'Twenty Twenty-Two',
 		zip: 'twentytwentytwo.latest-stable.zip',
 	},
 	{
 		url: 'https://wp-themes.com/twentytwentyone',
+		thumbnail: 'https://i0.wp.com/themes.svn.wordpress.org/twentytwentyone/1.7/screenshot.png?w=572&strip=all',
 		name: 'Twenty Twenty-One',
 		zip: 'twentytwentyone.latest-stable.zip',
 	},

--- a/wasm-demo/src/style.scss
+++ b/wasm-demo/src/style.scss
@@ -142,10 +142,16 @@
 		}
 		
 		.wporg-tab-item-list-item {
-			flex-basis: 49%;
+			border: 1px solid #dedede;
+			border-radius: 4px;
+			padding: 8px 12px;
 
-			a:hover {
-				text-decoration: none;;
+			a {
+				text-decoration: none;
+			}
+
+			&.is-active {
+				border-color: var(--wp--preset--color--vivid-cyan-blue);
 			}
 		}
 

--- a/wasm-demo/src/style.scss
+++ b/wasm-demo/src/style.scss
@@ -113,7 +113,7 @@
 			cursor: pointer;
 			transition: outline-color ease-in 0.1s;
 	
-			max-width: 200px;
+			max-width: 190px;
 			min-width: 100px;
 			flex-grow: 1;
 
@@ -122,7 +122,7 @@
 				outline: 1px solid var(--wp--preset--color--vivid-cyan-blue);
 				outline-width: 2px;
 			}
-			
+
 			a {
 				text-decoration: none;
 			}

--- a/wasm-demo/src/style.scss
+++ b/wasm-demo/src/style.scss
@@ -121,7 +121,10 @@
 				position: relative;
 				outline: 1px solid var(--wp--preset--color--vivid-cyan-blue);
 				outline-width: 2px;
-		
+			}
+			
+			a {
+				text-decoration: none;
 			}
 		}
 

--- a/wasm-demo/src/style.scss
+++ b/wasm-demo/src/style.scss
@@ -211,12 +211,22 @@
 
 .wporg-setup-footer {
 	position: fixed;
-	background-color: #fff;
 	bottom: 0;
 	left:0;
+
+	display: flex;
+    justify-content: flex-end;
 	padding: 1rem;
-	width: 100%;
-	border-top: 1px solid var(--wp--preset--color--light-grey-1);
+    width: 100%;
+    box-sizing: border-box;
+
+	background-color: #fff;
+	border-top: 1px solid var(--wp--preset--color--light-grey-1);	
+	
+	.wporg-tab-item-list__confirm {
+		font-size: 1.5em;
+		padding: 0.9em 1em;
+	}
 }
 
 .wporg-setup-modal {


### PR DESCRIPTION
# Description

This PR kicks off a configurable demo page of the [WordPress Sandbox](https://wasm.wordpress.net/wordpress.html) – to be hosted on WordPress.org:

<img width="1049" alt="CleanShot 2022-11-29 at 22 39 18@2x" src="https://user-images.githubusercontent.com/205419/204663976-768dd5b0-df61-4260-bbb2-1cbb3c1d1e1c.png">

<img width="908" alt="CleanShot 2022-11-29 at 22 27 56@2x" src="https://user-images.githubusercontent.com/205419/204662269-7e938770-cf30-4455-a8a5-f798f73c93e4.png">

For starters, it brings [the browser-like experience we currently have in the wordpress-wasm project](https://wasm.wordpress.net/wordpress.html) to the theme. It also allows users to overlay the settings so there isn't a context shift when wanting to change the theme or the pre-installed plugins.

Eventually, this page will cover the whats and hows of the project: What is it useful for? How to get started? How to contribute? For now, though, it's just a simple demo with plugins and themes selection.