### PR TITLE
Accessibility: Add aria label to settings button

### DIFF
--- a/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/playground.js
+++ b/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/playground.js
@@ -4,6 +4,7 @@
 import { Button, Flex, FlexItem } from '@wordpress/components';
 import { useRef, forwardRef, useState, useEffect } from '@wordpress/element';
 import { Icon, settings } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -96,6 +97,7 @@ export default forwardRef(({ showSettingsModal, theme, plugins }, ref) => {
 							onClick={showSettingsModal}
 							variant="tertiary"
 							className="wporg-demo__settings-button"
+							aria-label={__('Settings', 'wasm-demo')}
 						>
 							<Icon icon={settings} />
 						</Button>


### PR DESCRIPTION
- Closes https://github.com/WordPress/wordpress-playground/issues/613

## Description
It adds an `aria-label` on the settings button for `create-block/wasm-demo` block.


## Testing instructions

- In a terminal run:
  - `yarn install`
  - `composer install`
  - `yarn wp-env start` # to start the main server
- In a new terminal run: 
  - `cd source/wp-content/themes/wporg-wasm/src/wasm-demo`
  - `nvm use v14.21.3`
  - `yarn install`
  - `yarn start` # to start the wasm demo block
- Go to `/wp-admin`
- Activate the theme `Wasm` if it's not active yet.
- Create a new page
- Embed the block `wasm demo`
- View the forntend page
- Inspect the settings button
- Observe it has the `aria-label`
- Run [axe chrome extension](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd)
- Observe there is one less error.

## Screenshot
<img width="854" alt="Screenshot 2023-08-24 at 14 25 03" src="https://github.com/WordPress/wporg-wasm/assets/779993/7abdd876-40bb-4025-bbc2-bc91d48f1b20">

