### PR TITLE
Accessibility: Add title to input url bar

### DIFF
--- a/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/playground.js
+++ b/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/playground.js
@@ -4,6 +4,7 @@
 import { Button, Flex, FlexItem } from '@wordpress/components';
 import { useRef, forwardRef, useState, useEffect } from '@wordpress/element';
 import { Icon, settings } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -81,6 +82,7 @@ export default forwardRef(({ showSettingsModal, theme, plugins }, ref) => {
 								type="text"
 								autoComplete="off"
 								className="wpplayground-url-bar__input"
+								title={__('Playground URL', 'wasm-demo')}
 							/>
 						</div>
 						<input


### PR DESCRIPTION
- Closes https://github.com/WordPress/wordpress-playground/issues/615

## Description
It adds an `aria-label` to the URL input bar for `create-block/wasm-demo` block.


## Testing instructions

- In a terminal run:
  - `yarn install`
  - `composer install`
  - `yarn wp-env start` # to start the main server
- In a new terminal run: 
  - `cd source/wp-content/themes/wporg-wasm/src/wasm-demo`
  - `nvm use v14.21.3`
  - `yarn install`
  - `yarn start` # to start the wasm demo block
- Go to `/wp-admin`
- Activate the theme `Wasm` if it's not active yet.
- Create a new page
- Embed the block `wasm demo`
- View the forntend page
- Inspect the settings input url bar with class `wpplayground-url-bar__input`
- Observe it has the `title`
- Run [axe chrome extension](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd)
- Observe there is one less error.

## Screenshot

<img width="1303" alt="Screenshot 2023-08-24 at 15 01 34" src="https://github.com/WordPress/wporg-wasm/assets/779993/625a5170-9c35-49a6-88cb-2d38ee9609f1">


