### PR TITLE
Accessibility: Add label to plugin checkboxes on settings modal

### DIFF
--- a/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/settings/settings-modal.js
+++ b/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/settings/settings-modal.js
@@ -113,40 +113,47 @@ export default function SettingsModal({
 						gap="8px"
 					>
 						{availablePlugins.map((plugin) => (
-							<FlexItem
-								key={plugin.zip}
-								className={
-									'wporg-tab-item-list-item ' +
-									(activePlugins.includes(plugin)
-										? 'is-active'
-										: '')
-								}
-								onClick={() => toggleActivePlugin(plugin)}
-							>
-								<Flex align="center" direction="row" gap={2}>
-									<FlexItem>
-										<img
-											src={plugin.icon}
-											alt={plugin.name}
-										/>
-									</FlexItem>
-									<FlexBlock
-										as="h3"
-										className="wporg-tab-item-list__item-name"
+							<label>
+								<FlexItem
+									key={plugin.zip}
+									className={
+										'wporg-tab-item-list-item ' +
+										(activePlugins.includes(plugin)
+											? 'is-active'
+											: '')
+									}
+								>
+									{' '}
+									<Flex
+										align="center"
+										direction="row"
+										gap={2}
 									>
-										{plugin.name}
-									</FlexBlock>
-									<FlexItem>
-										<CheckboxControl
-											label={plugin.name}
-											checked={activePlugins.includes(
-												plugin
-											)}
-											onChange={() => {}}
-										/>
-									</FlexItem>
-								</Flex>
-							</FlexItem>
+										<FlexItem>
+											<img
+												src={plugin.icon}
+												alt={plugin.name}
+											/>
+										</FlexItem>
+										<FlexBlock
+											as="h3"
+											className="wporg-tab-item-list__item-name"
+										>
+											{plugin.name}
+										</FlexBlock>
+										<FlexItem>
+											<CheckboxControl
+												checked={activePlugins.includes(
+													plugin
+												)}
+												onChange={() =>
+													toggleActivePlugin(plugin)
+												}
+											/>
+										</FlexItem>
+									</Flex>
+								</FlexItem>
+							</label>
 						))}
 					</Flex>
 

--- a/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/settings/settings-modal.js
+++ b/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/settings/settings-modal.js
@@ -43,7 +43,8 @@ export default function SettingsModal({
 			<p>
 				Welcome to a new and exciting way of testing WordPress Themes
 				and Plugins. Choose a theme, sprinkle with a plugin or a few,
-				and start a new WordPress Playground – all inside of your browser!
+				and start a new WordPress Playground – all inside of your
+				browser!
 			</p>
 
 			<Flex wrap={true}>
@@ -137,7 +138,7 @@ export default function SettingsModal({
 									</FlexBlock>
 									<FlexItem>
 										<CheckboxControl
-											label=""
+											label={plugin.name}
 											checked={activePlugins.includes(
 												plugin
 											)}


### PR DESCRIPTION
- Closes https://github.com/WordPress/wordpress-playground/issues/617

## Description
It re-uses the already existing text as a label for plugin checkboxes on the settings modal

## Testing instructions

- In a terminal run:
  - `yarn install`
  - `composer install`
  - `yarn wp-env start` # to start the main server
- In a new terminal run: 
  - `cd source/wp-content/themes/wporg-wasm/src/wasm-demo`
  - `nvm use v14.21.3`
  - `yarn install`
  - `yarn start` # to start the wasm demo block
- Go to `/wp-admin`
- Activate the theme `Wasm` if it's not active yet.
- Create a new page
- Embed the block `wasm demo`
- View the forntend page
- Click on the settings button to open the modal
- Inspect the checkboxes
- Observe there is a new label element wrapping the checkbox items.
- Run [axe chrome extension](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd)
- Observe there are seven less errors.

## Screenshot

**Before**

<img width="1728" alt="Screenshot 2023-08-24 at 15 19 58" src="https://github.com/WordPress/wporg-wasm/assets/779993/e0f65efb-4b6b-49df-855e-b50838df44d6">


**After**

<img width="1728" alt="Screenshot 2023-08-24 at 15 24 57" src="https://github.com/WordPress/wporg-wasm/assets/779993/464bf139-bf78-4e70-ac7d-0c46446aef1d">



