### PR TITLE
Accessibility: Replace `h4` with `h2` on settings modal titles

### DIFF
--- a/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/settings/settings-modal.js
+++ b/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/settings/settings-modal.js
@@ -48,9 +48,9 @@ export default function SettingsModal({
 
 			<Flex wrap={true}>
 				<FlexItem>
-					<h4 className="wporg-setup-modal__section-title">
+					<h2 className="wporg-setup-modal__section-title">
 						Select a theme
-					</h4>
+					</h2>
 					<Flex
 						as="ul"
 						justify="flex-start"
@@ -99,12 +99,12 @@ export default function SettingsModal({
 						))}
 					</Flex>
 
-					<h4
+					<h2
 						className="wporg-setup-modal__section-title"
 						style={{ marginTop: -20 }}
 					>
 						Add plugins
-					</h4>
+					</h2>
 					<Flex
 						className="wporg-tab-item-list is-plugin"
 						justify="flex-start"


### PR DESCRIPTION
- Closes https://github.com/WordPress/wordpress-playground/issues/618

## Description
It changes the header level on modal settings for `create-block/wasm-demo` block.


## Testing instructions

- In a terminal run:
  - `yarn install`
  - `composer install`
  - `yarn wp-env start` # to start the main server
- In a new terminal run: 
  - `cd source/wp-content/themes/wporg-wasm/src/wasm-demo`
  - `nvm use v14.21.3`
  - `yarn install`
  - `yarn start` # to start the wasm demo block
- Go to `/wp-admin`
- Activate the `Wasm` theme if it's not active yet.
- Create a new page
- Embed the block `wasm demo`
- View the forntend page
- Click on the settings button
- Inspect the titles `Select a theme` and `Add plugins`
- Observe they are `h2` instead of `h4`
- I couldn't reproduce the issue with [axe chrome extension](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd)

## Screenshot

**Before**
<img width="1840" alt="Screenshot 2023-08-24 at 15 47 46" src="https://github.com/WordPress/wporg-wasm/assets/779993/f728eaa2-1d26-46d5-a5a9-26d65c607938">


**After**
<img width="1840" alt="Screenshot 2023-08-24 at 15 48 09" src="https://github.com/WordPress/wporg-wasm/assets/779993/c96b3bdd-e069-4bca-8d6c-13f5048ea948">

