### PR TITLE
Accessibility: Add the word `Theme:` to img alts for themes on settings modal

### DIFF
--- a/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/settings/settings-modal.js
+++ b/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/settings/settings-modal.js
@@ -43,7 +43,8 @@ export default function SettingsModal({
 			<p>
 				Welcome to a new and exciting way of testing WordPress Themes
 				and Plugins. Choose a theme, sprinkle with a plugin or a few,
-				and start a new WordPress Playground – all inside of your browser!
+				and start a new WordPress Playground – all inside of your
+				browser!
 			</p>
 
 			<Flex wrap={true}>
@@ -82,7 +83,7 @@ export default function SettingsModal({
 												<img
 													className="wporg-tab-item-list__theme-thumbnail"
 													src={theme.thumbnail}
-													alt={theme.name}
+													alt={`Theme: ${theme.name}`}
 												/>
 											</div>
 										</FlexItem>


### PR DESCRIPTION
- Closes https://github.com/WordPress/wordpress-playground/issues/619

## Description
It adds modifies the theme image alts on settings modal so they are different from the text below.


## Testing instructions

- In a terminal run:
  - `yarn install`
  - `composer install`
  - `yarn wp-env start` # to start the main server
- In a new terminal run: 
  - `cd source/wp-content/themes/wporg-wasm/src/wasm-demo`
  - `nvm use v14.21.3`
  - `yarn install`
  - `yarn start` # to start the wasm demo block
- Go to `/wp-admin`
- Activate the `Wasm` theme if it's not active yet.
- Create a new page
- Embed the block `wasm demo`
- View the forntend page
- Click on settings button
- Inspect the theme images
- Observe the alt images are different from the text below.
- Couldn't reproduce the issue using [axe chrome extension](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd)

## Screenshot

**Before**
<img width="1728" alt="Screenshot 2023-08-24 at 16 01 04" src="https://github.com/WordPress/wporg-wasm/assets/779993/56a52687-2c9c-416c-a218-0bde09b83a8c">

**After**
<img width="1840" alt="Screenshot 2023-08-24 at 16 02 17" src="https://github.com/WordPress/wporg-wasm/assets/779993/eeb590f0-a0df-456f-b336-f1cef4ef2143">

