### PR TITLE
Update the iframed URL from wasm.wordpress.net url to playground.wordpress.net

### DIFF
--- a/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/playground.js
+++ b/source/wp-content/themes/wporg-wasm/src/wasm-demo/src/components/playground.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  */
 import Iframe from './iframe';
 
-const BASE_URL = 'https://wasm.wordpress.net/wordpress.html';
+const BASE_URL = 'https://playground.wordpress.net/';
 
 export default forwardRef(({ showSettingsModal, theme, plugins }, ref) => {
 	const [url, setUrl] = useState('');


### PR DESCRIPTION
https://wordpress.org/playground/demo/?step=playground&theme=pendant shows the WordPress PR previewer because it loads an outdated URL: https://wasm.wordpress.net/wordpres.html

There was a redirect in place, but it broke during the migration to the atomic platform. Instead of addressing the issue with server-side redirects in Playground, let's actually load the correct URL:
 
![CleanShot 2024-09-17 at 22 26 07@2x](https://github.com/user-attachments/assets/8566e8f9-f7a7-445e-b744-334b19048bb3)

cc @StevenDufresne, would you be able to merge and deploy this on w.org/playground?

fyi @brandonpayton
